### PR TITLE
fix: include stderr content in runNativePlugin exception

### DIFF
--- a/core-common/src/main/java/io/roastedroot/protobuf4j/common/Protobuf.java
+++ b/core-common/src/main/java/io/roastedroot/protobuf4j/common/Protobuf.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 @WasmModuleInterface(value = WasmResource.absoluteFile)
 public final class Protobuf {
@@ -121,10 +120,20 @@ public final class Protobuf {
 
                 instanceBuilder.apply(imports);
             } catch (RuntimeException e) {
-                LOGGER.log(Level.SEVERE, "Error running protoc native plugin ", e);
-                System.out.println(stdout);
-                System.err.println(stderr);
-                throw new RuntimeException("Error running protoc native plugin.", e);
+                String stderrContent = stderr.toString(StandardCharsets.UTF_8);
+                LOGGER.log(Level.SEVERE, "Error running protoc native plugin: " + stderrContent, e);
+                if (LOGGER.isLoggable(Level.FINE)) {
+                    LOGGER.log(
+                            Level.FINE,
+                            "protoc stdout ({0} bytes): {1}",
+                            new Object[] {stdout.size(), stdout.toString(StandardCharsets.UTF_8)});
+                    LOGGER.log(Level.FINE, "protoc stderr: {0}", stderrContent);
+                }
+                String detail = "Error running protoc native plugin. stderr:\n" + stderrContent;
+                if (stdout.size() > 0) {
+                    detail += "\nstdout: " + stdout.size() + " bytes (binary, not shown)";
+                }
+                throw new RuntimeException(detail, e);
             }
 
             return PluginProtos.CodeGeneratorResponse.parseFrom(stdout.toByteArray());
@@ -191,7 +200,7 @@ public final class Protobuf {
         } catch (IOException e) {
             throw new RuntimeException(
                     "Failed to generate java files from proto files "
-                            + fileNames.stream().collect(Collectors.joining(", ")),
+                            + String.join(", ", fileNames),
                     e);
         }
     }

--- a/core-test/src/main/java/io/roastedroot/protobuf4j/test/AbstractPluginTest.java
+++ b/core-test/src/main/java/io/roastedroot/protobuf4j/test/AbstractPluginTest.java
@@ -1,6 +1,7 @@
 package io.roastedroot.protobuf4j.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.protobuf.DescriptorProtos;
@@ -8,6 +9,7 @@ import com.google.protobuf.compiler.PluginProtos;
 import io.roastedroot.protobuf4j.common.Protobuf;
 import io.roastedroot.zerofs.Configuration;
 import io.roastedroot.zerofs.ZeroFs;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -106,5 +108,47 @@ public abstract class AbstractPluginTest {
                 kotlinFileName.startsWith("examples/HelloWorldProtoKt"),
                 "Expected Kotlin file starting with examples/HelloWorldProtoKt, got: "
                         + kotlinFileName);
+    }
+
+    @Test
+    public void shouldIncludeStderrInExceptionOnPluginFailure() throws Exception {
+        FileSystem fs =
+                ZeroFs.newFileSystem(
+                        Configuration.unix().toBuilder().setAttributeViews("unix").build());
+        var workdir = fs.getPath(".");
+
+        String protoA =
+                "syntax = \"proto3\";\n"
+                        + "package duptest;\n"
+                        + "message Msg { string name = 1; }\n";
+        String protoB =
+                "syntax = \"proto3\";\n" + "package duptest;\n" + "message Msg { int32 id = 1; }\n";
+
+        Files.write(workdir.resolve("a.proto"), protoA.getBytes(StandardCharsets.UTF_8));
+        Files.write(workdir.resolve("b.proto"), protoB.getBytes(StandardCharsets.UTF_8));
+        var adapter = createAdapter(workdir);
+
+        var setA = adapter.getDescriptors(List.of("a.proto"));
+        var setB = adapter.getDescriptors(List.of("b.proto"));
+
+        PluginProtos.CodeGeneratorRequest request =
+                PluginProtos.CodeGeneratorRequest.newBuilder()
+                        .addFileToGenerate("a.proto")
+                        .addFileToGenerate("b.proto")
+                        .addAllProtoFile(setA.getFileList())
+                        .addAllProtoFile(setB.getFileList())
+                        .build();
+
+        RuntimeException ex =
+                assertThrows(
+                        RuntimeException.class,
+                        () ->
+                                adapter.runNativePlugin(
+                                        Protobuf.NativePlugin.JAVA, request, workdir));
+
+        assertTrue(
+                ex.getMessage().contains("already defined in file"),
+                "Exception should contain protoc's stderr describing the conflict, got: "
+                        + ex.getMessage());
     }
 }


### PR DESCRIPTION
The caught RuntimeException was printing stdout/stderr to System.out/err but not attaching them to the thrown exception. Callers wrapping the exception lost protoc's diagnostic output.  This would allow upstream plugins to better react to errors found in the native plugin.

Now the exception message includes stderr inline and notes stdout byte count when non-empty. Raw stdout/stderr are still available at FINE log level for debugging.

Added a test to prove functionality.  Keeps the console clean.

Also used string join instead of collectors - one less import and does the same thing